### PR TITLE
Allow Ajax requests to get unauthenticated (401). Inertia.isAjax = false

### DIFF
--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -1,12 +1,16 @@
 import grails.plugin.inertia.Inertia
+
+import javax.servlet.http.HttpServletRequest
+
 grails {
     plugin {
-       springsecurity {
-            ajaxHeader = "" // Disable default header based ajax matching
-            ajaxCheckClosure  = { request ->
-                // Enable inertia aware ajax: Inertia requests _LOOK_ like ajax, but are meant to be treated like standard navigation
-                if ("XMLHttpRequest" == request.getHeader("X-Requested-With")) {
-                    return !(request.getHeader(Inertia.INERTIA_HEADER) as Boolean)
+        springsecurity {
+            ajaxHeader = '' // Disable default header based ajax matching
+            ajaxCheckClosure = { HttpServletRequest request ->
+                /** Enable inertia aware ajax:
+                 * Inertia requests _LOOK_ like ajax, but are meant to be treated like standard navigation */
+                if ('XMLHttpRequest' == request.getHeader('X-Requested-With')) {
+                    return !Inertia.isInertiaRequest
                 }
                 return false
             }

--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -1,0 +1,15 @@
+import grails.plugin.inertia.Inertia
+grails {
+    plugin {
+       springsecurity {
+            ajaxHeader = "" // Disable default header based ajax matching
+            ajaxCheckClosure  = { request ->
+                // Enable inertia aware ajax: Inertia requests _LOOK_ like ajax, but are meant to be treated like standard navigation
+                if ("XMLHttpRequest" == request.getHeader("X-Requested-With")) {
+                    return !(request.getHeader(Inertia.INERTIA_HEADER) as Boolean)
+                }
+                return false
+            }
+        }
+    }
+}

--- a/grails-app/controllers/pingcrm/controller/LoginController.groovy
+++ b/grails-app/controllers/pingcrm/controller/LoginController.groovy
@@ -38,11 +38,6 @@ class LoginController extends grails.plugin.springsecurity.LoginController {
     }
 
     @Override
-    def authAjax() {
-        redirect(controller: 'login')
-    }
-
-    @Override
     def authfail() {
 
         def errors = [:]
@@ -65,10 +60,5 @@ class LoginController extends grails.plugin.springsecurity.LoginController {
     @Override
     def denied() {
         renderInertia('Error/Index', [status: 403])
-    }
-
-    @Override
-    def ajaxDenied() {
-        denied()
     }
 }


### PR DESCRIPTION
This example project uses the Grails Spring Security plugin to manage authentication which assumes standard page navigations OR ajax authentication, however the Grails Inertia plugin uses Inertia requests which leads to in-page navigation requests having the `X-Requested-With: XMLHttpRequest` header.  

Should a page visit occur after token expiration, or from an permitAll page to an isAuthenticated page the user will generate an ajax request, receive a 302 redirect to authAjax from spring security (due to the header), and then the custom login controller will redirect to the index method which finally contains the renderInertia function. 

The above solution works so long as there are no further (separate) ajax requests being made by the UI, which in more complex applications is not a great assumption to make. Inertia+Vue together make a very powerful SPA framework, however token expiration or access to separate isAuthenticated resources precludes the use of front end ajax since now the login controller will only ever redirect until a 200 status is received. This results in (axios in the case where the user is following Inertia docs) axios requests receiving HTML (html.gsp) in the request's response.data.

The following PR aims to solve this problem by providing a simple configuration workaround which integrates inertia awareness into the spring security plugin. The situational ajax awareness allows for true axios ajax requests to receive a proper 401 status code, thus letting the user handle token expiration, while also allowing Inertia requests to be treated like full navigation (as intended) and results in direct redirects to the index method.