### PR TITLE
build: Remove `webdriver-binaries` gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'application'
     id 'groovy'
     id 'war'
-    id 'com.github.erdi.webdriver-binaries'
     id 'com.github.node-gradle.node'
     id 'com.gorylenko.gradle-git-properties'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -16,7 +16,6 @@ dependencies {
 
     implementation buildsrcLibs.gitProperties.gradlePlugin
     implementation buildsrcLibs.node.gradlePlugin
-    implementation buildsrcLibs.webdriverBinaries.gradlePlugin
 
     // Needed for schemaExport Grails command/Gradle task
     //implementation buildsrcLibs.grailsHibernate5

--- a/gradle/buildsrc.libs.versions.toml
+++ b/gradle/buildsrc.libs.versions.toml
@@ -5,7 +5,6 @@ grails-gradle-plugin = '6.2.3'
 grails-views = '3.2.3'
 node-gradle-plugin = '7.1.0'
 spring-boot = '2.7.18'
-webdriver-binaries = '3.2'
 
 [libraries]
 gitProperties-gradlePlugin = { module = 'com.gorylenko.gradle-git-properties:gradle-git-properties', version.ref = 'git-properties-gradle-plugin' }
@@ -15,4 +14,3 @@ grails-gradlePlugin = { module = 'org.grails:grails-gradle-plugin', version.ref 
 grailsViews-gradlePlugin = { module = 'org.grails.plugins:views-gradle', version.ref = 'grails-views' }
 node-gradlePlugin = { module = 'com.github.node-gradle:gradle-node-plugin', version.ref = 'node-gradle-plugin' }
 springBoot-gradlePlugin = { module = 'org.springframework.boot:spring-boot-gradle-plugin', version.ref = 'spring-boot' }
-webdriverBinaries-gradlePlugin = { module = 'com.github.erdi:webdriver-binaries-gradle-plugin', version.ref = 'webdriver-binaries' }


### PR DESCRIPTION
`webdriver-binaries` is no longer needed as `ContainerGebSpec` is used.